### PR TITLE
Fix for: DefaultCommandProxy does not pass domain to CommandAdapters.cre...

### DIFF
--- a/src/main/org/spicefactory/lib/command/lifecycle/CommandLifecycle.as
+++ b/src/main/org/spicefactory/lib/command/lifecycle/CommandLifecycle.as
@@ -18,7 +18,9 @@ package org.spicefactory.lib.command.lifecycle {
 
 import org.spicefactory.lib.command.CommandResult;
 import org.spicefactory.lib.command.data.CommandData;
-	
+
+import flash.system.ApplicationDomain;
+
 /**
  * Represents the lifecycle of a command.
  * This is a hook that can be used by frameworks to add functionality to the command execution.
@@ -60,6 +62,9 @@ public interface CommandLifecycle {
 	 */
 	function afterCompletion (command:Object, result:CommandResult) : void;
 	
-	
+	/**
+	 * Lifecycle access to the domain for this command.
+	 */
+	function get domain () : ApplicationDomain;
 }
 }

--- a/src/main/org/spicefactory/lib/command/lifecycle/DefaultCommandLifecycle.as
+++ b/src/main/org/spicefactory/lib/command/lifecycle/DefaultCommandLifecycle.as
@@ -37,7 +37,7 @@ import flash.system.ApplicationDomain;
 public class DefaultCommandLifecycle implements CommandLifecycle {
 
 
-	private var domain:ApplicationDomain;
+	private var _domain:ApplicationDomain;
 
 
 	/**
@@ -46,7 +46,7 @@ public class DefaultCommandLifecycle implements CommandLifecycle {
 	 * @param domain the domain to use for reflecting on command classes
 	 */
 	function DefaultCommandLifecycle (domain:ApplicationDomain = null) {
-		this.domain = domain;
+		_domain = domain;
 	}
 
 	
@@ -54,7 +54,7 @@ public class DefaultCommandLifecycle implements CommandLifecycle {
 	 * @inheritDoc
 	 */
 	public function createInstance (type:Class, data:CommandData) : Object {
-		var info:ClassInfo = ClassInfo.forClass(type, domain);
+		var info:ClassInfo = ClassInfo.forClass(type, _domain);
 		var params:Array = [];
 		for each (var param:Parameter in info.getConstructor().parameters) {
 			var value:Object = data.getObject(param.type.getClass());
@@ -86,6 +86,13 @@ public class DefaultCommandLifecycle implements CommandLifecycle {
 		/* default implementation does nothing */
 	}
 	
+	/**
+	 * @inheritDoc
+	 */
+	public function get domain () : ApplicationDomain {
+		return _domain;
+	}
+
 	
 }
 }

--- a/src/main/org/spicefactory/lib/command/proxy/DefaultCommandProxy.as
+++ b/src/main/org/spicefactory/lib/command/proxy/DefaultCommandProxy.as
@@ -121,7 +121,7 @@ public class DefaultCommandProxy extends AbstractCommandExecutor implements Comm
 				var target:Object = lifecycle.createInstance(_type, data);
 				_target = (target is Command)
 					? target as Command
-					: CommandAdapters.createAdapter(target);
+					: CommandAdapters.createAdapter(target, lifecycle.domain);
 			}
 			catch (e:Error) {
 				error(new CommandFailure(this, _target, e));


### PR DESCRIPTION
...ateAdapter

This was breaking certain command invocations for multi-context applications. The adapter
was always looking in the root ApplicationDomain and unable to find commands bundled
with modules. Now it uses the domain associated with the command lifecycle.

I submitted a JIRA ticket for this: (http://opensource.powerflasher.com/jira/browse/COM-26)

See the commit notes. Thanks!
